### PR TITLE
feat(auth): add refresh tokens and rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,8 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.17.1",
     "nodemailer": "^7.0.5",
-    "resend": "^6.0.1"
+    "resend": "^6.0.1",
+    "express-rate-limit": "^7.1.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,12 +1,12 @@
-import bcrypt from 'bcrypt';
-import jwt from 'jsonwebtoken';
-import User from './../models/User.js';
-import { generateToken, hashToken } from './../utils/token.js';
-import { sendEmail } from './../utils/mailer.js';
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+const { generateToken, hashToken } = require('../utils/token');
+const { sendEmail } = require('../utils/mailer');
 
-const SALT_ROUNDS = 12;
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "1h";
-const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000";
+const SALT_ROUNDS = Number(process.env.SALT_ROUNDS) || 12;
+const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '1h';
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
 
 function signJwt(user) {
   return jwt.sign(
@@ -16,175 +16,136 @@ function signJwt(user) {
   );
 }
 
-export const register = async (req, res) => {
+// REGISTER USER AND SEND EMAIL VERIFICATION
+exports.register = async (req, res) => {
   try {
-    const { name, email, password } = req.body;
-
-    const existingUser = await User.findOne({ email });
-    if (existingUser) {
-      return res.status(400).json({ message: "Email is already registered." });
+    const { name, email, password } = req.body || {};
+    if (!email || !password) {
+      return res.status(400).json({ message: 'Email and password are required.' });
     }
 
-    // 2. Hash password
-    const salt = await bcrypt.genSalt(10);
-    const hashedPassword = await bcrypt.hash(password, salt);
+    const existing = await User.findOne({ email: String(email).toLowerCase() });
+    if (existing) {
+      return res.status(400).json({ message: 'Email is already registered.' });
+    }
 
-    const newUser = new User({ name, email, password: hashedPassword, isVerified: false, });
-    await newUser.save();
+    const hash = await bcrypt.hash(password, SALT_ROUNDS);
 
-    const token = jwt.sign({ userId: newUser._id }, process.env.JWT_SECRET, {
-      expiresIn: "1h",
+    const verifyToken = generateToken();
+    const user = await User.create({
+      name,
+      email: String(email).toLowerCase(),
+      password: hash,
+      isVerified: false,
+      emailVerificationTokenHash: hashToken(verifyToken),
+      emailVerificationTokenExpires: new Date(Date.now() + 60 * 60 * 1000),
     });
 
-    const verifyUrl = `${process.env.FRONTEND_URL}/auth/verify-email?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}`;
-
-     // DEBUG: log the token & url (safe in dev, remove in prod)
-    console.log('[REGISTER] verification token:', token);
-    console.log('[REGISTER] verification url:', verifyUrl);
+    const verifyUrl = `${FRONTEND_URL}/auth/verify-email?token=${verifyToken}&email=${encodeURIComponent(user.email)}`;
 
     await sendEmail(
-      email,
-      "Verify Your Email",
-      `<h2>Welcome, ${name}</h2>
-       <p>Please verify your email by clicking below:</p>
-       <a href="${verifyUrl}" target="_blank">Verify Email</a>`
+      user.email,
+      'Verify Your Email',
+      `<h2>Welcome, ${user.name || ''}</h2><p>Please verify your email by clicking below:</p><a href="${verifyUrl}" target="_blank">Verify Email</a>`
     );
 
-    res
-      .status(201)
-      .json({ message: "User registered. Verification email sent." });
-  } catch (error) {
-    console.error(error);
-    res.status(500).json({ message: "Server error. Please try again." });
+    return res.status(201).json({ message: 'User registered. Verification email sent.' });
+  } catch (err) {
+    console.error('[REGISTER]', err);
+    return res.status(500).json({ message: 'Server error. Please try again.' });
   }
 };
 
-export const verifyEmail = async (req, res) => {
- try {
-    const token = req.query?.token || req.body?.token;
-    if (!token) {
-      return res.status(400).json({ message: 'Verification token is missing' });
+// VERIFY EMAIL WITH HASHED TOKEN
+exports.verifyEmail = async (req, res) => {
+  try {
+    const token = req.query.token || req.body.token;
+    const email = req.query.email || req.body.email;
+    if (!token || !email) {
+      return res.status(400).json({ message: 'Verification token and email required.' });
     }
 
-    console.log('[VERIFY] raw token received (start):', token.slice(0, 50) + (token.length > 50 ? '...' : ''));
+    const user = await User.findOne({
+      email: String(email).toLowerCase(),
+      emailVerificationTokenHash: hashToken(token),
+      emailVerificationTokenExpires: { $gt: Date.now() },
+    });
 
-    // Show decoded payload without verifying (for debugging)
-    try {
-      const decoded = jwt.decode(token);
-      console.log('[VERIFY] decoded (no-verify) token payload:', decoded);
-    } catch (err) {
-      console.warn('[VERIFY] decode error (non-fatal):', err);
+    if (!user) {
+      return res.status(400).json({ message: 'Token invalid or expired.' });
     }
-
-    if (!process.env.JWT_SECRET) {
-      console.error('[VERIFY] JWT_SECRET missing!');
-      return res.status(500).json({ message: 'Server misconfiguration' });
-    }
-
-    let payload;
-    try {
-      payload = jwt.verify(token, process.env.JWT_SECRET);
-    } catch (err) {
-      console.error('[VERIFY] jwt.verify error:', err.name, err.message);
-      if (err.name === 'TokenExpiredError') {
-        return res.status(400).json({ message: 'Verification token has expired.' });
-      }
-      // Invalid signature / malformed token
-      return res.status(400).json({ message: 'Invalid verification token.' });
-    }
-
-    console.log('[VERIFY] verified payload:', payload);
-
-    const userId = payload?.userId || payload?.sub;
-    if (!userId) {
-      return res.status(400).json({ message: 'Invalid verification token (no userId).' });
-    }
-
-    const user = await User.findById(userId);
-    if (!user) return res.status(404).json({ message: 'User not found.' });
-
-    if (user.isVerified) return res.json({ message: 'Email already verified.' });
 
     user.isVerified = true;
+    user.emailVerificationTokenHash = undefined;
+    user.emailVerificationTokenExpires = undefined;
     await user.save();
 
     return res.json({ message: 'Email verified successfully' });
   } catch (err) {
-    console.error('[VERIFY] unexpected error:', err);
+    console.error('[VERIFY]', err);
     return res.status(500).json({ message: 'Server error' });
   }
 };
 
-export const login = async (req, res) => {
+// LOGIN AND ISSUE TOKENS
+exports.login = async (req, res) => {
   try {
-    const { email, password } = req.body || {};
+    const { email, password, remember } = req.body || {};
     if (!email || !password) {
       return res.status(400).json({ message: 'Email and password are required' });
     }
 
-    // normalize email
     const user = await User.findOne({ email: String(email).toLowerCase() });
-    if (!user) {
-      return res.status(404).json({ message: 'User not found' });
-    }
+    if (!user) return res.status(404).json({ message: 'User not found' });
 
-    // provider guard (if user created via google)
     if (user.provider && user.provider !== 'local') {
       return res.status(400).json({ message: `Please sign in using ${user.provider}` });
     }
 
-    // make sure password field exists
-    const storedHash = user.password || user.passwordHash || null;
-    if (!storedHash) {
-      // This is a developer error: user has no password saved
-      console.error('[LOGIN] user has no password hash stored for', user.email);
-      return res.status(500).json({ message: 'Server error' });
-    }
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) return res.status(401).json({ message: 'Incorrect password' });
 
-    const isMatch = await bcrypt.compare(password, storedHash);
-    if (!isMatch) {
-      return res.status(401).json({ message: 'Incorrect password' });
-    }
-
-    if (!user.isVerified) {
-      return res.status(403).json({ message: 'Email is not verified' });
-    }
+    if (!user.isVerified) return res.status(403).json({ message: 'Email is not verified' });
 
     const token = signJwt(user);
+    const refreshToken = generateToken();
+    user.refreshTokenHash = hashToken(refreshToken);
+    const days = remember ? 30 : 7;
+    user.refreshTokenExpires = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+    await user.save();
 
-    // Return token and sanitized user object
     return res.json({
       token,
+      refreshToken,
       user: {
         id: user._id.toString(),
         name: user.name,
         email: user.email,
         isVerified: user.isVerified,
-        role: user.role
-      }
+        role: user.role,
+      },
     });
   } catch (err) {
-    console.error('[LOGIN] error:', err);
+    console.error('[LOGIN]', err);
     return res.status(500).json({ message: 'Server error' });
   }
 };
 
-export const oauthLogin = async (req, res) => {
-  // Called by frontend after Google sign-in (NextAuth) with profile info
+// OAUTH LOGIN (GOOGLE)
+exports.oauthLogin = async (req, res) => {
   try {
-    const { email, name, provider } = req.body;
-    if (!email) return res.status(400).json({ message: "Email required" });
+    const { email, name, provider } = req.body || {};
+    if (!email) return res.status(400).json({ message: 'Email required' });
 
-    let user = await User.findOne({ email });
+    let user = await User.findOne({ email: String(email).toLowerCase() });
     if (!user) {
       user = await User.create({
-        email,
+        email: String(email).toLowerCase(),
         name,
-        provider: provider || "google",
+        provider: provider || 'google',
         isVerified: true,
       });
     } else {
-      // Update provider if necessary
       user.provider = provider || user.provider;
       user.name = user.name || name;
       user.isVerified = true;
@@ -192,82 +153,114 @@ export const oauthLogin = async (req, res) => {
     }
 
     const token = signJwt(user);
-    return res.json({
-      token,
-      user: { id: user._id, email: user.email, name: user.name },
-    });
+    return res.json({ token, user: { id: user._id, email: user.email, name: user.name } });
   } catch (err) {
-    console.error(err);
-    return res.status(500).json({ message: "Server error" });
+    console.error('[OAUTH]', err);
+    return res.status(500).json({ message: 'Server error' });
   }
 };
 
-export const forgotPassword = async (req, res) => {
+// FORGOT PASSWORD
+exports.forgotPassword = async (req, res) => {
   try {
-    const { email } = req.body;
-    const user = await User.findOne({ email });
-
+    const { email } = req.body || {};
+    const user = await User.findOne({ email: String(email).toLowerCase() });
     if (!user) {
       return res.status(400).json({ message: 'User with this email does not exist.' });
     }
 
-    const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, { expiresIn: '15m' });
+    const token = generateToken();
+    user.resetPasswordTokenHash = hashToken(token);
+    user.resetPasswordTokenExpires = new Date(Date.now() + 15 * 60 * 1000);
+    await user.save();
 
-user.resetPasswordTokenHash = hashToken(token);
-user.resetPasswordTokenExpires = Date.now() + 15 * 60 * 1000;
-await user.save();
-console.log(token,"token forgotPassword")
-    const resetUrl = `${process.env.FRONTEND_URL}/auth/reset-password?token=${token}&email=${encodeURIComponent(email)}`;
+    const resetUrl = `${FRONTEND_URL}/auth/reset-password?token=${token}&email=${encodeURIComponent(user.email)}`;
 
     await sendEmail(
-      email,
+      user.email,
       'Password Reset Request',
-      `<h2>Hello,</h2>
-       <p>Click below to reset your password:</p>
-       <a href="${resetUrl}" target="_blank">Reset Password</a>
-       <p>This link will expire in 15 minutes.</p>`
+      `<h2>Hello,</h2><p>Click below to reset your password:</p><a href="${resetUrl}" target="_blank">Reset Password</a><p>This link will expire in 15 minutes.</p>`
     );
 
-    res.status(200).json({ message: 'Password reset email sent.' });
-  } catch (error) {
-    console.error(error);
-    res.status(500).json({ message: 'Server error. Please try again.' });
+    return res.json({ message: 'Password reset email sent.' });
+  } catch (err) {
+    console.error('[FORGOT]', err);
+    return res.status(500).json({ message: 'Server error. Please try again.' });
   }
 };
 
-
-export const resetPassword = async (req, res) => {
+// RESET PASSWORD
+exports.resetPassword = async (req, res) => {
   try {
     const { token, email, newPassword } = req.body || {};
-    if (!token || !email || !newPassword) return res.status(400).json({ message: 'Missing parameters' });
+    if (!token || !email || !newPassword) {
+      return res.status(400).json({ message: 'Missing parameters' });
+    }
 
-    const hashed = hashToken(token);
     const user = await User.findOne({
       email: String(email).toLowerCase(),
-      resetPasswordTokenHash: hashed,
-      resetPasswordTokenExpires: { $gt: Date.now() }
+      resetPasswordTokenHash: hashToken(token),
+      resetPasswordTokenExpires: { $gt: Date.now() },
     });
-console.log(token,"token resetPassword")
 
     if (!user) return res.status(400).json({ message: 'Token invalid or expired' });
 
-    const newHash = await bcrypt.hash(newPassword, Number(process.env.SALT_ROUNDS) || 12);
+    const newHash = await bcrypt.hash(newPassword, SALT_ROUNDS);
     user.password = newHash;
-    user.passwordHash = newHash;
     user.resetPasswordTokenHash = undefined;
     user.resetPasswordTokenExpires = undefined;
     user.passwordChangedAt = new Date();
-
     await user.save();
 
     return res.json({ message: 'Password reset successful' });
   } catch (err) {
-    console.error('[RESET] error:', err);
+    console.error('[RESET]', err);
     return res.status(500).json({ message: 'Server error' });
   }
 };
-export const logout = () => {
-  // If using cookies for JWT
-    res.clearCookie("token");
-    return res.json({ message: "Logged out successfully" });
+
+// REFRESH ACCESS TOKEN
+exports.refreshToken = async (req, res) => {
+  try {
+    const { refreshToken } = req.body || {};
+    if (!refreshToken) return res.status(400).json({ message: 'Refresh token required' });
+
+    const user = await User.findOne({
+      refreshTokenHash: hashToken(refreshToken),
+      refreshTokenExpires: { $gt: Date.now() },
+    });
+
+    if (!user) return res.status(401).json({ message: 'Invalid refresh token' });
+
+    const token = signJwt(user);
+    const newRefreshToken = generateToken();
+    user.refreshTokenHash = hashToken(newRefreshToken);
+    user.refreshTokenExpires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    await user.save();
+
+    return res.json({ token, refreshToken: newRefreshToken });
+  } catch (err) {
+    console.error('[REFRESH]', err);
+    return res.status(500).json({ message: 'Server error' });
+  }
 };
+
+// LOGOUT AND REVOKE REFRESH TOKEN
+exports.logout = async (req, res) => {
+  try {
+    const { refreshToken } = req.body || {};
+    if (refreshToken) {
+      const user = await User.findOne({ refreshTokenHash: hashToken(refreshToken) });
+      if (user) {
+        user.refreshTokenHash = undefined;
+        user.refreshTokenExpires = undefined;
+        await user.save();
+      }
+    }
+    return res.json({ message: 'Logged out successfully' });
+  } catch (err) {
+    console.error('[LOGOUT]', err);
+    return res.status(500).json({ message: 'Server error' });
+  }
+};
+

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,19 +1,23 @@
-import mongoose from 'mongoose';
+const mongoose = require('mongoose');
 
-const userSchema = new mongoose.Schema({
-  name: { type: String },
-  email: { type: String, required: true, unique: true, lowercase: true },
-  password: { type: String, required: true },
-  isVerified: { type: Boolean, default: false },
-  role: { type: String, default: 'user' },
-  provider: { type: String, default: 'local' },
-  createdAt: { type: Date, default: Date.now },
-  emailVerificationTokenHash: { type: String },
-  emailVerificationTokenExpires: { type: Date },
-  resetPasswordTokenHash: { type: String },
-  resetPasswordTokenExpires: { type: Date },
-}, { timestamps: true });
+const userSchema = new mongoose.Schema(
+  {
+    name: { type: String },
+    email: { type: String, required: true, unique: true, lowercase: true },
+    password: { type: String, required: true },
+    isVerified: { type: Boolean, default: false },
+    role: { type: String, default: 'user' },
+    provider: { type: String, default: 'local' },
+    createdAt: { type: Date, default: Date.now },
+    emailVerificationTokenHash: { type: String },
+    emailVerificationTokenExpires: { type: Date },
+    resetPasswordTokenHash: { type: String },
+    resetPasswordTokenExpires: { type: Date },
+    refreshTokenHash: { type: String },
+    refreshTokenExpires: { type: Date },
+  },
+  { timestamps: true }
+);
 
-// ✅ Use ESM export
-const User = mongoose.model('User', userSchema);
-export default User;
+module.exports = mongoose.model('User', userSchema);
+

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,6 +1,17 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const router = express.Router();
 const authController = require('../controllers/authController');
+
+// Rate limiting for auth routes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+router.use(limiter);
 
 router.post('/register', authController.register);
 router.get('/verify-email', authController.verifyEmail);
@@ -8,5 +19,6 @@ router.post('/login', authController.login);
 router.post('/oauth-login', authController.oauthLogin);
 router.post('/forgot-password', authController.forgotPassword);
 router.post('/reset-password', authController.resetPassword);
-router.post("/logout", authController.logout);
+router.post('/refresh-token', authController.refreshToken);
+router.post('/logout', authController.logout);
 module.exports = router;

--- a/backend/src/utils/mailer.js
+++ b/backend/src/utils/mailer.js
@@ -1,14 +1,9 @@
-import { Resend } from 'resend';
+const { Resend } = require('resend');
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-/**
- * Send email using Resend API
- * @param {string} to - Receiver email
- * @param {string} subject - Email subject
- * @param {string} html - HTML content
- */
-export const sendEmail = async (to, subject, html) => {
+// Send email using Resend API
+async function sendEmail(to, subject, html) {
   try {
     const response = await resend.emails.send({
       from: 'Help Circle <onboarding@resend.dev>',
@@ -18,13 +13,15 @@ export const sendEmail = async (to, subject, html) => {
     });
 
     if (response.error) {
-      console.error("Resend API Error:", response.error);
+      console.error('Resend API Error:', response.error);
       throw new Error(response.error.message);
     }
 
     return response;
   } catch (error) {
     console.error('Email sending failed (full):', error);
-    throw new Error(error.message); // Keep actual error for now
+    throw new Error(error.message);
   }
-};
+}
+
+module.exports = { sendEmail };

--- a/frontend/src/app/auth/signin/page.jsx
+++ b/frontend/src/app/auth/signin/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 import { signIn } from 'next-auth/react';
 import { useState } from 'react';
-import { Button, Form, Input, Typography, message } from 'antd';
+import { Button, Form, Input, Typography, message, Checkbox } from 'antd';
 import { GoogleOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -11,10 +11,11 @@ export default function SignIn() {
   const router = useRouter();
 
 const onFinish = async (values) => {
-  const res = await signIn("credentials", {
+  const res = await signIn('credentials', {
     redirect: false,
     email: values.email,
     password: values.password,
+    remember: values.remember ? 'true' : 'false',
     callbackUrl: `${window.location.origin}/home`
   });
 
@@ -36,8 +37,11 @@ const onFinish = async (values) => {
           <Form.Item name="email" label="Email" rules={[{ required: true, message: 'Email required' }]}>
             <Input />
           </Form.Item>
-          <Form.Item name="password" label="Password" rules={[{ required: true, message: 'Password required' }]}>
+          <Form.Item name="password" label="Password" rules={[{ required: true, message: 'Password required' }]}> 
             <Input.Password />
+          </Form.Item>
+          <Form.Item name="remember" valuePropName="checked" initialValue={false}>
+            <Checkbox>Remember me</Checkbox>
           </Form.Item>
           <Form.Item>
             <Button loading={loading} type="primary" htmlType="submit" block>

--- a/frontend/src/pages/api/auth/[...nextauth].ts
+++ b/frontend/src/pages/api/auth/[...nextauth].ts
@@ -36,7 +36,8 @@ export const authOptions: NextAuthOptions = {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             email: credentials.email,
-            password: credentials.password
+            password: credentials.password,
+            remember: credentials.remember === 'true'
           })
         });
 
@@ -65,8 +66,8 @@ export const authOptions: NextAuthOptions = {
           id: data.user.id || data.user._id,
           name: data.user.name,
           email: data.user.email,
-          // attach token for callbacks (optional)
-          accessToken: data.token
+          accessToken: data.token,
+          refreshToken: data.refreshToken
         };
       }
     }),
@@ -84,12 +85,14 @@ export const authOptions: NextAuthOptions = {
       if (user) {
         token.user = user;
         token.accessToken = (user as any).accessToken || token.accessToken;
+        token.refreshToken = (user as any).refreshToken || token.refreshToken;
       }
       return token;
     },
     async session({ session, token }) {
-      session.user = token.user as any || session.user;
+      session.user = (token.user as any) || session.user;
       (session as any).accessToken = token.accessToken;
+      (session as any).refreshToken = token.refreshToken;
       return session;
     },
     async redirect({ url, baseUrl }) {


### PR DESCRIPTION
## Summary
- secure user registration and email verification tokens
- add refresh token flow with DB storage and logout/renew endpoints
- rate-limit auth routes and enable remember-me UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec8f33048322a77a043d96b2780f